### PR TITLE
fix: replace sha1 of crypto-hash with own implementation #76

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test:ci": "vitest run --coverage --reporter=default --reporter=junit --outputFile=./junit.xml"
   },
   "dependencies": {
-    "crypto-hash": "^3.0.0",
     "uint8array-extras": "^1.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  crypto-hash:
-    specifier: ^3.0.0
-    version: 3.0.0
   uint8array-extras:
     specifier: ^1.1.0
     version: 1.1.0
@@ -1034,11 +1031,6 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
     dev: true
-
-  /crypto-hash@3.0.0:
-    resolution: {integrity: sha512-5l5xGtzuvGTU28GXxGV1JYVFou68buZWpkV1Fx5hIDRPnfbQ8KzabTlNIuDIeSCYGVPFehupzDqlnbXm2IXmdQ==}
-    engines: {node: '>=18'}
-    dev: false
 
   /data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}

--- a/src/torrentFile.ts
+++ b/src/torrentFile.ts
@@ -1,9 +1,21 @@
+import { createHash } from 'node:crypto';
 import { join, sep } from 'node:path';
 
-import { sha1 } from 'crypto-hash';
 import { isUint8Array, uint8ArrayToHex, uint8ArrayToString } from 'uint8array-extras';
 
 import { decode, encode } from './bencode/index.js';
+
+/**
+ * Generates sha1 hash of the given arrayBuffer
+ * @param arrayBuffer ArrayBuffer to hash
+ * @returns sha1 hash of the given arrayBuffer in hex format
+ */
+function sha1(arrayBuffer: ArrayBuffer): Promise<string> {
+  const buffer = Buffer.from(arrayBuffer);
+  const hash = createHash("sha1");
+  hash.update(buffer);
+  return Promise.resolve(hash.digest("hex"));
+}
 
 /**
  * sha1 of torrent file info. This hash is commenly used by torrent clients as the ID of the torrent.


### PR DESCRIPTION
As described in #76

We've tried it out, run the tests in this project, added our own released version of it [meierschlumpf-torrent-file](https://www.npmjs.com/package/meierschlumpf-torrent-file), added this one to a clone of qbittorrent, run the tests, released a package of it [@meierschlumpf/qbittorrent](https://www.npmjs.com/package/@meierschlumpf/qbittorrent) and tried it out in our code (The build was successful and the functionality worked as expected)